### PR TITLE
Updates sdl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mold2d"
-version = "0.0.2"
+version = "0.1.0"
 authors = ["Darin Minamoto <darinm223@gmail.com>"]
 description = "A simple platformer game library in Rust"
 repository = "https://github.com/DarinM223/mold2d"
@@ -10,6 +10,7 @@ license = "MIT"
 
 [dependencies]
 libc = "0.2"
+lazy_static = "0.2"
 
 [dependencies.sdl2]
 version = "0.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ license = "MIT"
 
 [dependencies]
 libc = "0.2"
-sdl2 = "0.9"
-sdl2_image = "0.3"
-sdl2_ttf = "0.9"
+
+[dependencies.sdl2]
+version = "0.29"
+default-features = false
+features = ["ttf", "image"]
 
 [lib]
 doctest = false

--- a/examples/mario/Cargo.toml
+++ b/examples/mario/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Darin Minamoto <darinm223@gmail.com>"]
 
 [dependencies]
 rand = "0.3"
-cpuprofiler = "0.0.3"
 clippy = { version = "*", optional = true }
 
 [dependencies.mold2d]

--- a/examples/mario/Cargo.toml
+++ b/examples/mario/Cargo.toml
@@ -5,13 +5,16 @@ authors = ["Darin Minamoto <darinm223@gmail.com>"]
 
 [dependencies]
 rand = "0.3"
-sdl2 = "0.9"
-sdl2_image = "0.3"
-sdl2_ttf = "0.9"
+cpuprofiler = "0.0.3"
 clippy = { version = "*", optional = true }
 
 [dependencies.mold2d]
 path = "../../"
+
+[dependencies.sdl2]
+version = "0.29"
+default-features = false
+features = ["ttf", "image"]
 
 [profile.release]
 debug = true

--- a/examples/mario/src/actions.rs
+++ b/examples/mario/src/actions.rs
@@ -127,19 +127,19 @@ pub fn handle_collision(actor: &mut Box<Actor>,
             };
 
             actor.handle_message(&ActorMessage::ActorAction {
-                send_id: -1,
-                recv_id: -1,
-                action: ActorAction::ChangePosition(change),
-            });
+                                      send_id: -1,
+                                      recv_id: -1,
+                                      action: ActorAction::ChangePosition(change),
+                                  });
         }
 
         if direction == CollisionSide::Bottom {
             let down_change = PositionChange::new().down(1);
             actor.handle_message(&ActorMessage::ActorAction {
-                send_id: -1,
-                recv_id: -1,
-                action: ActorAction::ChangePosition(down_change),
-            });
+                                      send_id: -1,
+                                      recv_id: -1,
+                                      action: ActorAction::ChangePosition(down_change),
+                                  });
         }
     }
 

--- a/examples/mario/src/actors/coin.rs
+++ b/examples/mario/src/actors/coin.rs
@@ -3,6 +3,7 @@ use mold2d::{Actor, AnimatedSprite, BoundingBox, Collision, CollisionSide, Posit
              Context, Renderable, Spritesheet, SpritesheetConfig, SpriteRectangle, Viewport};
 use sdl2::rect::Rect;
 use sdl2::render::Renderer;
+use std::error::Error;
 
 const COIN_VALUE: i32 = 5;
 
@@ -63,7 +64,7 @@ impl Actor for Coin {
     }
 
     fn collides_with(&mut self, other_actor: &ActorData) -> Option<CollisionSide> {
-        self.rect.collides_with(other_actor.rect)
+        self.rect.collides_with(&other_actor.rect)
     }
 
     fn update(&mut self, _context: &mut Context, elapsed: f64) -> PositionChange {
@@ -72,12 +73,16 @@ impl Actor for Coin {
         PositionChange::new()
     }
 
-    fn render(&mut self, context: &mut Context, viewport: &mut Viewport, _elapsed: f64) {
+    fn render(&mut self,
+              context: &mut Context,
+              viewport: &mut Viewport,
+              _elapsed: f64)
+              -> Result<(), Box<Error>> {
         let (rx, ry) = viewport.relative_point((self.rect.x, self.rect.y));
         let rect = Rect::new(rx, ry, self.rect.w, self.rect.h);
 
         // Render sprite animation
-        self.animation.render(&mut context.renderer, rect);
+        self.animation.render(&mut context.renderer, rect)
     }
 
     fn data(&mut self) -> ActorData {
@@ -87,7 +92,7 @@ impl Actor for Coin {
             damage: 0,
             collision_filter: 0b1111,
             resolves_collisions: false,
-            rect: self.rect.to_sdl().unwrap(),
+            rect: self.rect.to_sdl(),
             bounding_box: Some(BoundingBox::Rectangle(self.rect.clone())),
             actor_type: ActorType::Item,
         }

--- a/examples/mario/src/actors/coin.rs
+++ b/examples/mario/src/actors/coin.rs
@@ -74,7 +74,7 @@ impl Actor for Coin {
 
     fn render(&mut self, context: &mut Context, viewport: &mut Viewport, _elapsed: f64) {
         let (rx, ry) = viewport.relative_point((self.rect.x, self.rect.y));
-        let rect = Rect::new_unwrap(rx, ry, self.rect.w, self.rect.h);
+        let rect = Rect::new(rx, ry, self.rect.w, self.rect.h);
 
         // Render sprite animation
         self.animation.render(&mut context.renderer, rect);

--- a/examples/mario/src/main.rs
+++ b/examples/mario/src/main.rs
@@ -1,16 +1,14 @@
-#![feature(custom_attribute, plugin)]
-#[cfg_attr(feature="clippy", feature(plugin))]
-#[cfg_attr(feature="clippy", plugin(clippy))]
 #[macro_use(block)]
 extern crate mold2d;
+
+extern crate cpuprofiler;
 extern crate sdl2;
-extern crate sdl2_image;
-extern crate sdl2_ttf;
 
 pub mod actions;
 pub mod actors;
 pub mod views;
 
+use cpuprofiler::PROFILER;
 use mold2d::Window;
 use mold2d::event_loop;
 use views::game_view::GameView;
@@ -22,9 +20,11 @@ fn main() {
         height: 600,
     };
 
+    PROFILER.lock().unwrap().start("./my-prof.profile").unwrap();
     let result = event_loop::create_event_loop(window, |context| {
         Box::new(GameView::new("levels/level1.txt", context))
     });
+    PROFILER.lock().unwrap().stop().unwrap();
 
     match result {
         Ok(_) => println!("Game exited successfully!"),

--- a/examples/mario/src/main.rs
+++ b/examples/mario/src/main.rs
@@ -1,14 +1,12 @@
 #[macro_use(block)]
 extern crate mold2d;
 
-extern crate cpuprofiler;
 extern crate sdl2;
 
 pub mod actions;
 pub mod actors;
 pub mod views;
 
-use cpuprofiler::PROFILER;
 use mold2d::Window;
 use mold2d::event_loop;
 use views::game_view::GameView;
@@ -20,11 +18,9 @@ fn main() {
         height: 600,
     };
 
-    PROFILER.lock().unwrap().start("./my-prof.profile").unwrap();
     let result = event_loop::create_event_loop(window, |context| {
         Box::new(GameView::new("levels/level1.txt", context))
     });
-    PROFILER.lock().unwrap().stop().unwrap();
 
     match result {
         Ok(_) => println!("Game exited successfully!"),

--- a/examples/mario/src/views/background_view.rs
+++ b/examples/mario/src/views/background_view.rs
@@ -1,14 +1,16 @@
 use mold2d::{Context, View, ViewAction};
 use sdl2::pixels::Color;
+use std::error::Error;
 
 /// Test view that should display a background
 pub struct BackgroundView;
 
 impl View for BackgroundView {
-    fn render(&mut self, context: &mut Context, _elapsed: f64) {
+    fn render(&mut self, context: &mut Context, _elapsed: f64) -> Result<(), Box<Error>> {
         // TODO: Draw background (right now just draws red as background)
         context.renderer.set_draw_color(Color::RGB(255, 0, 0));
         context.renderer.clear();
+        Ok(())
     }
 
     fn update(&mut self, context: &mut Context, _elapsed: f64) -> Option<ViewAction> {

--- a/examples/mario/src/views/game_view.rs
+++ b/examples/mario/src/views/game_view.rs
@@ -92,7 +92,7 @@ impl View for GameView {
         }
 
         {
-            let window_rect = Rect::new_unwrap(0, 0, context.window.width, context.window.height);
+            let window_rect = Rect::new(0, 0, context.window.width, context.window.height);
             let viewport_clone = self.viewport.clone();
             let mut quadtree = Quadtree::new(window_rect, &viewport_clone);
             let mut keys = Vec::with_capacity(self.actors.actors.len());

--- a/src/block.rs
+++ b/src/block.rs
@@ -106,7 +106,7 @@ macro_rules! block {
                                  other_actor: &::mold2d::ActorData<$actor_type>)
                                  -> Option<::mold2d::CollisionSide> {
                     use ::mold2d::Collision;
-                    self.rect.collides_with(other_actor.rect)
+                    self.rect.collides_with(&other_actor.rect)
                 }
 
                 fn update(&mut self,
@@ -120,12 +120,12 @@ macro_rules! block {
                 fn render(&mut self,
                           context: &mut ::mold2d::Context,
                           viewport: &mut ::mold2d::Viewport,
-                          _elapsed: f64) {
+                          _elapsed: f64) -> Result<(), Box<::std::error::Error>> {
                     use ::mold2d::Renderable;
                     let (rx, ry) = viewport.relative_point((self.rect.x, self.rect.y));
                     let rect = ::sdl2::rect::Rect::new(rx, ry, self.rect.w, self.rect.h);
 
-                    self.sprite.render(&mut context.renderer, rect);
+                    self.sprite.render(&mut context.renderer, rect)
                 }
 
                 fn data(&mut self) -> ::mold2d::ActorData<$actor_type> {
@@ -135,7 +135,7 @@ macro_rules! block {
                         damage: 0,
                         resolves_collisions: false,
                         collision_filter: $filter,
-                        rect: self.rect.to_sdl().unwrap(),
+                        rect: self.rect.to_sdl(),
                         bounding_box: Some(::mold2d::BoundingBox::Rectangle(self.rect.clone())),
                         actor_type: $actor_type::Block,
                     }

--- a/src/block.rs
+++ b/src/block.rs
@@ -123,7 +123,7 @@ macro_rules! block {
                           _elapsed: f64) {
                     use ::mold2d::Renderable;
                     let (rx, ry) = viewport.relative_point((self.rect.x, self.rect.y));
-                    let rect = ::sdl2::rect::Rect::new_unwrap(rx, ry, self.rect.w, self.rect.h);
+                    let rect = ::sdl2::rect::Rect::new(rx, ry, self.rect.w, self.rect.h);
 
                     self.sprite.render(&mut context.renderer, rect);
                 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,14 +1,16 @@
-use sdl2_ttf::Font;
+use sdl2::ttf::{Font, Sdl2TtfContext};
 use sprite::Sprite;
 use std::collections::HashMap;
 use std::mem;
 use std::sync::{Arc, Mutex, ONCE_INIT, Once};
 
+pub static GlobalTtfContext: Sdl2TtfContext = Sdl2TtfContext;
+
 /// A global thread-safe cache for resolving fonts
 /// from file path
 #[derive(Clone)]
 pub struct FontCache {
-    pub cache: Arc<Mutex<HashMap<String, Font>>>,
+    pub cache: Arc<Mutex<HashMap<String, Font<'static, 'static>>>>,
 }
 
 /// Returns the font cache as a singleton
@@ -18,12 +20,13 @@ pub fn font_cache() -> FontCache {
 
     unsafe {
         ONCE.call_once(|| {
-            let singleton = FontCache { cache: Arc::new(Mutex::new(HashMap::new())) };
+                           let singleton =
+                               FontCache { cache: Arc::new(Mutex::new(HashMap::new())) };
 
-            SINGLETON = mem::transmute(Box::new(singleton));
+                           SINGLETON = mem::transmute(Box::new(singleton));
 
-            // TODO(DarinM223): clean up memory after exit
-        });
+                           // TODO(DarinM223): clean up memory after exit
+                       });
 
         (*SINGLETON).clone()
     }
@@ -43,12 +46,13 @@ pub fn sprite_cache() -> SpriteCache {
 
     unsafe {
         ONCE.call_once(|| {
-            let singleton = SpriteCache { cache: Arc::new(Mutex::new(HashMap::new())) };
+                           let singleton =
+                               SpriteCache { cache: Arc::new(Mutex::new(HashMap::new())) };
 
-            SINGLETON = mem::transmute(Box::new(singleton));
+                           SINGLETON = mem::transmute(Box::new(singleton));
 
-            // TODO(DarinM223): clean up memory after exit
-        });
+                           // TODO(DarinM223): clean up memory after exit
+                       });
 
         (*SINGLETON).clone()
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::mem;
 use std::sync::{Arc, Mutex, ONCE_INIT, Once};
 
-pub static GlobalTtfContext: Sdl2TtfContext = Sdl2TtfContext;
+pub static GLOBAL_TTF_CONTEXT: Sdl2TtfContext = Sdl2TtfContext;
 
 /// A global thread-safe cache for resolving fonts
 /// from file path

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 use std::mem;
 use std::sync::{Arc, Mutex, ONCE_INIT, Once};
 
-pub static GLOBAL_TTF_CONTEXT: Sdl2TtfContext = Sdl2TtfContext;
+lazy_static! {
+    pub static ref TTF_CONTEXT: Sdl2TtfContext = Sdl2TtfContext;
+}
 
 /// A global thread-safe cache for resolving fonts
 /// from file path
@@ -24,8 +26,6 @@ pub fn font_cache() -> FontCache {
                                FontCache { cache: Arc::new(Mutex::new(HashMap::new())) };
 
                            SINGLETON = mem::transmute(Box::new(singleton));
-
-                           // TODO(DarinM223): clean up memory after exit
                        });
 
         (*SINGLETON).clone()
@@ -50,8 +50,6 @@ pub fn sprite_cache() -> SpriteCache {
                                SpriteCache { cache: Arc::new(Mutex::new(HashMap::new())) };
 
                            SINGLETON = mem::transmute(Box::new(singleton));
-
-                           // TODO(DarinM223): clean up memory after exit
                        });
 
         (*SINGLETON).clone()

--- a/src/collision.rs
+++ b/src/collision.rs
@@ -254,22 +254,22 @@ mod tests {
 
     #[test]
     fn test_left_right_rect_collision() {
-        let left_rect = Rect::new_unwrap(-10, 0, 20, 20);
-        let right_rect = Rect::new_unwrap(0, 0, 20, 20);
+        let left_rect = Rect::new(-10, 0, 20, 20);
+        let right_rect = Rect::new(0, 0, 20, 20);
 
-        assert_eq!(left_rect.collides_with(right_rect),
+        assert_eq!(left_rect.collides_with(&right_rect),
                    Some(CollisionSide::Right));
-        assert_eq!(right_rect.collides_with(left_rect),
+        assert_eq!(right_rect.collides_with(&left_rect),
                    Some(CollisionSide::Left));
     }
 
     #[test]
     fn test_up_down_rect_collision() {
-        let up_rect = Rect::new_unwrap(0, -20, 20, 20);
-        let down_rect = Rect::new_unwrap(0, 0, 20, 20);
+        let up_rect = Rect::new(0, -20, 20, 20);
+        let down_rect = Rect::new(0, 0, 20, 20);
 
-        assert_eq!(up_rect.collides_with(down_rect),
+        assert_eq!(up_rect.collides_with(&down_rect),
                    Some(CollisionSide::Bottom));
-        assert_eq!(down_rect.collides_with(up_rect), Some(CollisionSide::Top));
+        assert_eq!(down_rect.collides_with(&up_rect), Some(CollisionSide::Top));
     }
 }

--- a/src/collision.rs
+++ b/src/collision.rs
@@ -152,11 +152,11 @@ pub fn print_collision_side_u8(direction: u8) {
 
 /// Checks collisions for different objects
 pub trait Collision<T> {
-    fn collides_with(&self, other: T) -> Option<CollisionSide>;
+    fn collides_with(&self, other: &T) -> Option<CollisionSide>;
 }
 
 impl Collision<Rect> for Rect {
-    fn collides_with(&self, other: Rect) -> Option<CollisionSide> {
+    fn collides_with(&self, other: &Rect) -> Option<CollisionSide> {
         let w = 0.5 * (self.width() + other.width()) as f64;
         let h = 0.5 * (self.height() + other.height()) as f64;
         let dx = center_point(self).0 - center_point(&other).0;
@@ -186,32 +186,20 @@ impl Collision<Rect> for Rect {
 }
 
 impl Collision<SpriteRectangle> for Rect {
-    fn collides_with(&self, other: SpriteRectangle) -> Option<CollisionSide> {
-        if let Some(rect) = other.to_sdl() {
-            return self.collides_with(rect);
-        }
-
-        None
+    fn collides_with(&self, other: &SpriteRectangle) -> Option<CollisionSide> {
+        self.collides_with(&other.to_sdl())
     }
 }
 
 impl Collision<Rect> for SpriteRectangle {
-    fn collides_with(&self, other: Rect) -> Option<CollisionSide> {
-        if let Some(rect) = self.to_sdl() {
-            return rect.collides_with(other);
-        }
-
-        None
+    fn collides_with(&self, other: &Rect) -> Option<CollisionSide> {
+        self.to_sdl().collides_with(other)
     }
 }
 
 impl Collision<SpriteRectangle> for SpriteRectangle {
-    fn collides_with(&self, other: SpriteRectangle) -> Option<CollisionSide> {
-        if let Some(rect) = other.to_sdl() {
-            return self.collides_with(rect);
-        }
-
-        None
+    fn collides_with(&self, other: &SpriteRectangle) -> Option<CollisionSide> {
+        self.collides_with(&other.to_sdl())
     }
 }
 
@@ -231,12 +219,11 @@ impl BoundingBox {
     }
 }
 
-impl<'a> Collision<&'a BoundingBox> for BoundingBox {
-    fn collides_with(&self, other: &'a BoundingBox) -> Option<CollisionSide> {
+impl Collision<BoundingBox> for BoundingBox {
+    fn collides_with(&self, other: &BoundingBox) -> Option<CollisionSide> {
         match (self, other) {
             (&BoundingBox::Rectangle(ref rect1), &BoundingBox::Rectangle(ref rect2)) => {
-                // TODO(DarinM223): avoid cloning the second rectangle
-                rect1.collides_with(rect2.clone())
+                rect1.collides_with(rect2)
             }
         }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,6 @@
 use events::Events;
 use score::Score;
 use sdl2::render::Renderer;
-use sdl2::image;
 
 /// Represents a SDL window to render
 pub struct Window {
@@ -23,8 +22,6 @@ impl<'a> Context<'a> {
     /// Creates a new context given the path for the keyboard configuration
     /// and the sdl renderer
     pub fn new(window: Window, events: Events, renderer: Renderer<'a>) -> Context<'a> {
-        image::init(image::INIT_PNG);
-
         Context {
             window: window,
             events: events,

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,7 @@
 use events::Events;
 use score::Score;
 use sdl2::render::Renderer;
-use sdl2_image;
+use sdl2::image;
 
 /// Represents a SDL window to render
 pub struct Window {
@@ -23,7 +23,7 @@ impl<'a> Context<'a> {
     /// Creates a new context given the path for the keyboard configuration
     /// and the sdl renderer
     pub fn new(window: Window, events: Events, renderer: Renderer<'a>) -> Context<'a> {
-        sdl2_image::init(sdl2_image::INIT_PNG);
+        image::init(image::INIT_PNG);
 
         Context {
             window: window,
@@ -31,11 +31,5 @@ impl<'a> Context<'a> {
             renderer: renderer,
             score: Score::new(),
         }
-    }
-}
-
-impl<'a> Drop for Context<'a> {
-    fn drop(&mut self) {
-        sdl2_image::quit();
     }
 }

--- a/src/event_loop/mod.rs
+++ b/src/event_loop/mod.rs
@@ -3,25 +3,25 @@ mod frame_timer;
 use context::{Context, Window};
 use events::Events;
 use sdl2;
-use sdl2::SdlResult;
-use sdl2_ttf;
 use self::frame_timer::{FrameAction, FrameTimer};
 use super::{View, ViewAction};
+use std::error::Error;
 
 /// Initializes SDL and creates the window and event loop
-pub fn create_event_loop<F>(window: Window, init_view: F) -> SdlResult<()>
+pub fn create_event_loop<F>(window: Window, init_view: F) -> Result<(), Box<Error>>
     where F: Fn(&mut Context) -> Box<View>
 {
     let sdl_context = try!(sdl2::init());
     let video = try!(sdl_context.video());
     let mut timer = try!(sdl_context.timer());
-    let _ttf_context = sdl2_ttf::init();
+    let _ttf_context = sdl2::ttf::init();
 
     let mut frame_timer = FrameTimer::new(&mut timer, true);
-    let sdl_window = try!(video.window(window.title, window.width, window.height)
-        .position_centered()
-        .opengl()
-        .build());
+    let sdl_window = try!(video
+                              .window(window.title, window.width, window.height)
+                              .position_centered()
+                              .opengl()
+                              .build());
     let sdl_renderer = try!(sdl_window.renderer().accelerated().build());
     let mut game_context = Context::new(window,
                                         Events::new(try!(sdl_context.event_pump()), ""),

--- a/src/event_loop/mod.rs
+++ b/src/event_loop/mod.rs
@@ -3,6 +3,7 @@ mod frame_timer;
 use context::{Context, Window};
 use events::Events;
 use sdl2;
+use sdl2::image::{INIT_PNG, INIT_JPG};
 use self::frame_timer::{FrameAction, FrameTimer};
 use super::{View, ViewAction};
 use std::error::Error;
@@ -11,20 +12,21 @@ use std::error::Error;
 pub fn create_event_loop<F>(window: Window, init_view: F) -> Result<(), Box<Error>>
     where F: Fn(&mut Context) -> Box<View>
 {
-    let sdl_context = try!(sdl2::init());
-    let video = try!(sdl_context.video());
-    let mut timer = try!(sdl_context.timer());
+    let sdl_context = sdl2::init()?;
+    let video = sdl_context.video()?;
+    let mut timer = sdl_context.timer()?;
+    let _image_context = sdl2::image::init(INIT_PNG | INIT_JPG)?;
     let _ttf_context = sdl2::ttf::init();
 
     let mut frame_timer = FrameTimer::new(&mut timer, true);
-    let sdl_window = try!(video
-                              .window(window.title, window.width, window.height)
-                              .position_centered()
-                              .opengl()
-                              .build());
-    let sdl_renderer = try!(sdl_window.renderer().accelerated().build());
+    let sdl_window = video
+        .window(window.title, window.width, window.height)
+        .position_centered()
+        .opengl()
+        .build()?;
+    let sdl_renderer = sdl_window.renderer().accelerated().build()?;
     let mut game_context = Context::new(window,
-                                        Events::new(try!(sdl_context.event_pump()), ""),
+                                        Events::new(sdl_context.event_pump()?, ""),
                                         sdl_renderer);
     let mut curr_view = init_view(&mut game_context);
 
@@ -42,7 +44,7 @@ pub fn create_event_loop<F>(window: Window, init_view: F) -> Result<(), Box<Erro
             _ => {}
         }
 
-        curr_view.render(&mut game_context, elapsed);
+        curr_view.render(&mut game_context, elapsed)?;
 
         // Render the scene
         game_context.renderer.present();

--- a/src/event_loop/mod.rs
+++ b/src/event_loop/mod.rs
@@ -16,11 +16,10 @@ pub fn create_event_loop<F>(window: Window, init_view: F) -> Result<(), Box<Erro
     let video = sdl_context.video()?;
     let mut timer = sdl_context.timer()?;
     let _image_context = sdl2::image::init(INIT_PNG | INIT_JPG)?;
-    let _ttf_context = sdl2::ttf::init();
+    let _ttf_context = sdl2::ttf::init()?;
 
     let mut frame_timer = FrameTimer::new(&mut timer, true);
-    let sdl_window = video
-        .window(window.title, window.width, window.height)
+    let sdl_window = video.window(window.title, window.width, window.height)
         .position_centered()
         .opengl()
         .build()?;

--- a/src/events/keyboard_mappings.rs
+++ b/src/events/keyboard_mappings.rs
@@ -30,7 +30,8 @@ impl KeyboardMappings {
     /// Creates a new keyboard mapper given a keyboard mapping string
     pub fn new(mappings: &str) -> KeyboardMappings {
         let mapping_str = mappings.to_owned();
-        let token_stream: Vec<_> = mapping_str.split(|x| (x == ' ') || (x == '\n'))
+        let token_stream: Vec<_> = mapping_str
+            .split(|x| (x == ' ') || (x == '\n'))
             .filter(|s| !s.trim().is_empty())
             .collect();
 

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,11 +1,11 @@
 use cache;
-use sdl2::SdlResult;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 use sdl2::render::Renderer;
-use sdl2_ttf;
-use sdl2_ttf::Font;
+use sdl2::ttf;
+use sdl2::ttf::Font;
 use sprite::{Renderable, Sprite};
+use std::error::Error;
 use std::path::Path;
 
 /// Returns a text sprite with the specified text, font, size, and color
@@ -14,14 +14,14 @@ pub fn text_sprite(renderer: &Renderer,
                    font_path: &'static str,
                    size: i32,
                    color: Color)
-                   -> SdlResult<Sprite> {
+                   -> Result<Sprite, Box<Error>> {
     let font_cache = cache::font_cache();
 
     // if font is cached use the cached font
     {
         if let Ok(ref cache) = font_cache.cache.lock() {
             if let Some(font) = cache.get(font_path) {
-                let surface = try!(font.render(text, sdl2_ttf::blended(color)));
+                let surface = try!(font.render(text).blended(color));
                 let texture = try!(renderer.create_texture_from_surface(&surface));
 
                 return Ok(Sprite::new(texture));
@@ -30,18 +30,21 @@ pub fn text_sprite(renderer: &Renderer,
     }
 
     // otherwise load font from file path
-    let font = try!(Font::from_file(Path::new(font_path), size));
+    let font = try!(cache::GlobalTtfContext.load_font(Path::new(font_path), 12));
     let sprite;
 
     {
-        let surface = try!(font.render(text, sdl2_ttf::blended(color)));
+        let surface = try!(font.render(text).blended(color));
         let texture = try!(renderer.create_texture_from_surface(&surface));
 
         sprite = Sprite::new(texture);
     }
 
     // cache if successful
-    let _ = font_cache.cache.lock().map(|ref mut cache| cache.insert(font_path.to_owned(), font));
+    let _ = font_cache
+        .cache
+        .lock()
+        .map(|ref mut cache| cache.insert(font_path.to_owned(), font));
 
     Ok(sprite)
 }
@@ -50,5 +53,5 @@ pub fn text_sprite(renderer: &Renderer,
 pub fn render_text(renderer: &mut Renderer, sprite: &Sprite, point: (i32, i32)) {
     let (x, y) = point;
     let (w, h) = sprite.size();
-    sprite.render(renderer, Rect::new_unwrap(x, y, w, h));
+    sprite.render(renderer, Rect::new(x, y, w, h));
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -2,8 +2,6 @@ use cache;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 use sdl2::render::Renderer;
-use sdl2::ttf;
-use sdl2::ttf::Font;
 use sprite::{Renderable, Sprite};
 use std::error::Error;
 use std::path::Path;
@@ -21,8 +19,8 @@ pub fn text_sprite(renderer: &Renderer,
     {
         if let Ok(ref cache) = font_cache.cache.lock() {
             if let Some(font) = cache.get(font_path) {
-                let surface = try!(font.render(text).blended(color));
-                let texture = try!(renderer.create_texture_from_surface(&surface));
+                let surface = font.render(text).blended(color)?;
+                let texture = renderer.create_texture_from_surface(&surface)?;
 
                 return Ok(Sprite::new(texture));
             }
@@ -30,12 +28,13 @@ pub fn text_sprite(renderer: &Renderer,
     }
 
     // otherwise load font from file path
-    let font = try!(cache::GlobalTtfContext.load_font(Path::new(font_path), 12));
+    let font = cache::GLOBAL_TTF_CONTEXT
+        .load_font(Path::new(font_path), 12)?;
     let sprite;
 
     {
-        let surface = try!(font.render(text).blended(color));
-        let texture = try!(renderer.create_texture_from_surface(&surface));
+        let surface = font.render(text).blended(color)?;
+        let texture = renderer.create_texture_from_surface(&surface)?;
 
         sprite = Sprite::new(texture);
     }
@@ -50,8 +49,11 @@ pub fn text_sprite(renderer: &Renderer,
 }
 
 /// Renders a text sprite at the specified point
-pub fn render_text(renderer: &mut Renderer, sprite: &Sprite, point: (i32, i32)) {
+pub fn render_text(renderer: &mut Renderer,
+                   sprite: &Sprite,
+                   point: (i32, i32))
+                   -> Result<(), Box<Error>> {
     let (x, y) = point;
     let (w, h) = sprite.size();
-    sprite.render(renderer, Rect::new(x, y, w, h));
+    sprite.render(renderer, Rect::new(x, y, w, h))
 }

--- a/src/font.rs
+++ b/src/font.rs
@@ -28,8 +28,7 @@ pub fn text_sprite(renderer: &Renderer,
     }
 
     // otherwise load font from file path
-    let font = cache::GLOBAL_TTF_CONTEXT
-        .load_font(Path::new(font_path), 12)?;
+    let font = cache::TTF_CONTEXT.load_font(Path::new(font_path), 12)?;
     let sprite;
 
     {

--- a/src/level.rs
+++ b/src/level.rs
@@ -27,7 +27,7 @@ pub fn load_level<A: Actor + ?Sized>(path: &str,
         let mut has_player = false;
 
         for line in reader.lines() {
-            for token in try!(line).chars() {
+            for token in line?.chars() {
                 if token != ' ' {
                     manager.add(token, (x, y), renderer);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@
 //! y axis, down is a positive change in the y axis, left is a negative
 //! change in the x axis, and right is a positive change in the x axis.
 
-#![feature(drop_types_in_const)]
-
+#[macro_use]
+extern crate lazy_static;
 extern crate libc;
 extern crate sdl2;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,11 +47,11 @@ pub use raycast::{Polygon, Segment};
 pub use score::Score;
 pub use sprite::{AnimatedSprite, Animations, Direction, Renderable, Sprite, Spritesheet,
                  SpritesheetConfig, SpriteRectangle};
-pub use sdl2::ttf::FontError;
 pub use vector::{PositionChange, Vector2D};
 pub use viewport::Viewport;
 
 use sdl2::rect::Rect;
+use std::error::Error;
 
 /// Handler for a view to deal with actor messages
 pub type MessageHandler<A: Actor + ?Sized> = Box<Fn(&mut Box<A>,
@@ -70,7 +70,7 @@ pub enum ViewAction {
 
 pub trait View {
     /// Called every frame to render a view
-    fn render(&mut self, context: &mut Context, elapsed: f64);
+    fn render(&mut self, context: &mut Context, elapsed: f64) -> Result<(), Box<Error>>;
 
     /// Called every frame to update a view
     fn update(&mut self, context: &mut Context, elapsed: f64) -> Option<ViewAction>;
@@ -105,7 +105,11 @@ pub trait Actor {
     type Message;
 
     /// Called every frame to render an actor
-    fn render(&mut self, context: &mut Context, viewport: &mut Viewport, elapsed: f64);
+    fn render(&mut self,
+              context: &mut Context,
+              viewport: &mut Viewport,
+              elapsed: f64)
+              -> Result<(), Box<Error>>;
 
     /// Handle a message sent by another actor
     fn handle_message(&mut self, message: &Self::Message) -> Self::Message;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,10 @@
 //! y axis, down is a positive change in the y axis, left is a negative
 //! change in the x axis, and right is a positive change in the x axis.
 
+#![feature(drop_types_in_const)]
+
 extern crate libc;
 extern crate sdl2;
-extern crate sdl2_image;
-extern crate sdl2_ttf;
 
 #[macro_use]
 pub mod block;
@@ -47,6 +47,7 @@ pub use raycast::{Polygon, Segment};
 pub use score::Score;
 pub use sprite::{AnimatedSprite, Animations, Direction, Renderable, Sprite, Spritesheet,
                  SpritesheetConfig, SpriteRectangle};
+pub use sdl2::ttf::FontError;
 pub use vector::{PositionChange, Vector2D};
 pub use viewport::Viewport;
 

--- a/src/quadtree.rs
+++ b/src/quadtree.rs
@@ -37,64 +37,71 @@ impl<'a, Type> Quadtree<'a, Type> {
         let (x, y) = (self.bounds.x(), self.bounds.y());
 
         if width as u32 > 0u32 && height as u32 > 0u32 {
-            self.nodes[0] = Some(Box::new(Quadtree {
-                level: self.level + 1,
-                objects: Vec::with_capacity(MAX_OBJECTS),
-                bounds: Rect::new_unwrap(x + width, y, width as u32, height as u32),
-                nodes: [None, None, None, None],
-                viewport: self.viewport,
-            }));
+            self.nodes[0] =
+                Some(Box::new(Quadtree {
+                                  level: self.level + 1,
+                                  objects: Vec::with_capacity(MAX_OBJECTS),
+                                  bounds: Rect::new(x + width, y, width as u32, height as u32),
+                                  nodes: [None, None, None, None],
+                                  viewport: self.viewport,
+                              }));
             self.nodes[1] = Some(Box::new(Quadtree {
-                level: self.level + 1,
-                objects: Vec::with_capacity(MAX_OBJECTS),
-                bounds: Rect::new_unwrap(x, y, width as u32, height as u32),
-                nodes: [None, None, None, None],
-                viewport: self.viewport,
-            }));
-            self.nodes[2] = Some(Box::new(Quadtree {
-                level: self.level + 1,
-                objects: Vec::with_capacity(MAX_OBJECTS),
-                bounds: Rect::new_unwrap(x, y + height, width as u32, height as u32),
-                nodes: [None, None, None, None],
-                viewport: self.viewport,
-            }));
+                                              level: self.level + 1,
+                                              objects: Vec::with_capacity(MAX_OBJECTS),
+                                              bounds: Rect::new(x, y, width as u32, height as u32),
+                                              nodes: [None, None, None, None],
+                                              viewport: self.viewport,
+                                          }));
+            self.nodes[2] =
+                Some(Box::new(Quadtree {
+                                  level: self.level + 1,
+                                  objects: Vec::with_capacity(MAX_OBJECTS),
+                                  bounds: Rect::new(x, y + height, width as u32, height as u32),
+                                  nodes: [None, None, None, None],
+                                  viewport: self.viewport,
+                              }));
             self.nodes[3] = Some(Box::new(Quadtree {
-                level: self.level + 1,
-                objects: Vec::with_capacity(MAX_OBJECTS),
-                bounds: Rect::new_unwrap(x + width, y + height, width as u32, height as u32),
-                nodes: [None, None, None, None],
-                viewport: self.viewport,
-            }));
+                                              level: self.level + 1,
+                                              objects: Vec::with_capacity(MAX_OBJECTS),
+                                              bounds: Rect::new(x + width,
+                                                                y + height,
+                                                                width as u32,
+                                                                height as u32),
+                                              nodes: [None, None, None, None],
+                                              viewport: self.viewport,
+                                          }));
         }
     }
 
     /// Determine which node index the object belongs to
     fn index(&self, rect: &Rect) -> Option<i32> {
-        self.viewport.constrain_to_viewport(rect).and_then(|rect| {
-            let vert_mid = (self.bounds.x() as f64) + (self.bounds.width() as f64) / 2.;
-            let horiz_mid = (self.bounds.y() as f64) + (self.bounds.height() as f64) / 2.;
+        self.viewport
+            .constrain_to_viewport(rect)
+            .and_then(|rect| {
+                let vert_mid = (self.bounds.x() as f64) + (self.bounds.width() as f64) / 2.;
+                let horiz_mid = (self.bounds.y() as f64) + (self.bounds.height() as f64) / 2.;
 
-            let top_quad = (rect.y() as f64) < horiz_mid &&
-                           (rect.y() as f64) + (rect.height() as f64) < horiz_mid;
-            let bot_quad = (rect.y() as f64) > horiz_mid;
+                let top_quad = (rect.y() as f64) < horiz_mid &&
+                               (rect.y() as f64) + (rect.height() as f64) < horiz_mid;
+                let bot_quad = (rect.y() as f64) > horiz_mid;
 
-            if (rect.x() as f64) < vert_mid &&
-               (rect.x() as f64) + (rect.width() as f64) < vert_mid {
-                if top_quad {
-                    return Some(1);
-                } else if bot_quad {
-                    return Some(2);
+                if (rect.x() as f64) < vert_mid &&
+                   (rect.x() as f64) + (rect.width() as f64) < vert_mid {
+                    if top_quad {
+                        return Some(1);
+                    } else if bot_quad {
+                        return Some(2);
+                    }
+                } else if (rect.x() as f64) > vert_mid {
+                    if top_quad {
+                        return Some(0);
+                    } else if bot_quad {
+                        return Some(3);
+                    }
                 }
-            } else if (rect.x() as f64) > vert_mid {
-                if top_quad {
-                    return Some(0);
-                } else if bot_quad {
-                    return Some(3);
-                }
-            }
 
-            None
-        })
+                None
+            })
     }
 
     /// Inserts an actor into the quadtree

--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -73,24 +73,22 @@ impl Polygon for Rect {
         let (f_x, f_y) = (self.x() as f64, self.y() as f64);
         let (f_w, f_h) = (self.width() as f64, self.height() as f64);
 
-        vec![
-            Segment {
-                point: (f_x, f_y),
-                vector: Vector2D { x: 0., y: f_h },
-            },
-            Segment {
-                point: (f_x, f_y + f_h),
-                vector: Vector2D { x: f_w, y: 0. },
-            },
-            Segment {
-                point: (f_x + f_w, f_y + f_h),
-                vector: Vector2D { x: 0., y: -f_h },
-            },
-            Segment {
-                point: (f_x + f_w, f_y),
-                vector: Vector2D { x: -f_w, y: 0. },
-            },
-        ]
+        vec![Segment {
+                 point: (f_x, f_y),
+                 vector: Vector2D { x: 0., y: f_h },
+             },
+             Segment {
+                 point: (f_x, f_y + f_h),
+                 vector: Vector2D { x: f_w, y: 0. },
+             },
+             Segment {
+                 point: (f_x + f_w, f_y + f_h),
+                 vector: Vector2D { x: 0., y: -f_h },
+             },
+             Segment {
+                 point: (f_x + f_w, f_y),
+                 vector: Vector2D { x: -f_w, y: 0. },
+             }]
     }
 
     fn collision_from_side(&self, id: usize) -> Option<CollisionSide> {
@@ -175,12 +173,22 @@ mod tests {
         let sides = rect.sides();
 
         assert_eq!(sides,
-                   vec![
-            Segment { point: (0., 0.), vector:  Vector2D { x: 0., y: 20. } },
-            Segment { point: (0., 20.), vector: Vector2D { x: 20., y: 0. } },
-            Segment { point: (20., 20.), vector: Vector2D { x: 0., y: -20. } },
-            Segment { point: (20., 0.), vector: Vector2D { x: -20., y: 0. } },
-        ]);
+                   vec![Segment {
+                            point: (0., 0.),
+                            vector: Vector2D { x: 0., y: 20. },
+                        },
+                        Segment {
+                            point: (0., 20.),
+                            vector: Vector2D { x: 20., y: 0. },
+                        },
+                        Segment {
+                            point: (20., 20.),
+                            vector: Vector2D { x: 0., y: -20. },
+                        },
+                        Segment {
+                            point: (20., 0.),
+                            vector: Vector2D { x: -20., y: 0. },
+                        }]);
     }
 
     #[test]

--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn test_rect_sides() {
-        let rect = Rect::new_unwrap(0, 0, 20, 20);
+        let rect = Rect::new(0, 0, 20, 20);
         let sides = rect.sides();
 
         assert_eq!(sides,
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn test_shorten_ray_left() {
-        let rect = Rect::new_unwrap(2, 3, 2, 2);
+        let rect = Rect::new(2, 3, 2, 2);
         let mut segment = Segment {
             point: (0., 3.),
             vector: Vector2D { x: 4., y: 0. },
@@ -254,7 +254,7 @@ mod tests {
 
     #[test]
     fn test_shorten_ray_top() {
-        let rect = Rect::new_unwrap(2, 3, 2, 2);
+        let rect = Rect::new(2, 3, 2, 2);
         let mut segment = Segment {
             point: (3., 0.),
             vector: Vector2D { x: 0., y: 4. },

--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -2,6 +2,7 @@ use collision::CollisionSide;
 use sdl2::pixels::Color;
 use sdl2::rect::{Point, Rect};
 use sdl2::render::Renderer;
+use std::error::Error;
 use vector::Vector2D;
 use viewport::Viewport;
 
@@ -51,12 +52,16 @@ impl Segment {
         self.vector.len()
     }
 
-    pub fn render(&self, color: Color, viewport: &mut Viewport, renderer: &mut Renderer) {
+    pub fn render(&self,
+                  color: Color,
+                  viewport: &mut Viewport,
+                  renderer: &mut Renderer)
+                  -> Result<(), Box<Error>> {
         let (rx, ry) = viewport.relative_point((self.point.0 as i32, self.point.1 as i32));
         let p1 = Point::new(rx as i32, ry as i32);
         let p2 = Point::new(rx + (self.vector.x as i32), ry + (self.vector.y as i32));
         renderer.set_draw_color(color);
-        renderer.draw_line(p1, p2);
+        renderer.draw_line(p1, p2).map_err(From::from)
     }
 }
 

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -7,8 +7,8 @@ use sdl2::rect::Rect;
 fn calc_viewport_point(center_coord: f64, window_coord: f64, map_coord: f64) -> f64 {
     let half = window_coord / 2.0;
 
-    ((center_coord - half).max(0.0))
-        .min((map_coord - window_coord).min((center_coord - half).abs()))
+    ((center_coord - half).max(0.0)).min((map_coord - window_coord).min((center_coord - half)
+                                                                            .abs()))
 }
 
 /// Constrains coordinates from an open world into the current window view
@@ -80,7 +80,7 @@ impl Viewport {
         if in_viewport {
             let center = center_point(rect);
             let (x, y) = self.relative_point((center.0 as i32, center.1 as i32));
-            Some(Rect::new_unwrap(x, y, rect.width(), rect.height()))
+            Some(Rect::new(x, y, rect.width(), rect.height()))
         } else {
             None
         }

--- a/src/viewport.rs
+++ b/src/viewport.rs
@@ -62,22 +62,27 @@ impl Viewport {
         (map_point.0 - self.x, map_point.1 - self.y)
     }
 
-    /// Returns a rectangle in viewport coordinates or None if not in viewport
-    pub fn constrain_to_viewport(&self, rect: &Rect) -> Option<Rect> {
+    /// Returns true if the rectangle is inside the viewport, false otherwise
+    pub fn rect_in_viewport(&self, rect: &Rect) -> bool {
+        let x_plus_width = rect.x() + rect.width() as i32;
+        let y_plus_height = rect.y() + rect.height() as i32;
         let rect_points = [(rect.x(), rect.y()),
-                           (rect.x() + (rect.width() as i32), rect.y()),
-                           (rect.x(), rect.y() + (rect.height() as i32)),
-                           (rect.x() + (rect.width() as i32), rect.y() + (rect.height() as i32))];
+                           (x_plus_width, rect.y()),
+                           (rect.x(), y_plus_height),
+                           (x_plus_width, y_plus_height)];
 
-        let mut in_viewport = false;
         for point in rect_points.iter() {
             if self.in_viewport(*point) {
-                in_viewport = true;
-                break;
+                return true;
             }
         }
 
-        if in_viewport {
+        false
+    }
+
+    /// Returns a rectangle in viewport coordinates or None if not in viewport
+    pub fn constrain_to_viewport(&self, rect: &Rect) -> Option<Rect> {
+        if self.rect_in_viewport(rect) {
             let center = center_point(rect);
             let (x, y) = self.relative_point((center.0 as i32, center.1 as i32));
             Some(Rect::new(x, y, rect.width(), rect.height()))


### PR DESCRIPTION
Updates to work with rust-sdl2 version 0.29 and modifies the following:

* Actor::render and View::render implementations have to return Result<(), Box<Error>>
* Collision::collides_with takes the parameter as a reference instead of moving
* SpriteRectangle::to_sdl() returns a Rect instead of a Option < Rect >