### PR TITLE
Upgrades rust-sdl2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ libc = "0.2"
 lazy_static = "1.5.0"
 
 [dependencies.sdl2]
-version = "0.29"
+version = "0.31"
 default-features = false
-features = ["ttf", "image"]
+features = ["ttf", "image", "unsafe_textures"]
 
 [lib]
 doctest = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ libc = "0.2"
 lazy_static = "1.5.0"
 
 [dependencies.sdl2]
-version = "0.31"
+version = "0.37"
 default-features = false
 features = ["ttf", "image", "unsafe_textures"]
 

--- a/examples/mario/Cargo.toml
+++ b/examples/mario/Cargo.toml
@@ -12,9 +12,9 @@ clippy = { version = "*", optional = true }
 path = "../../"
 
 [dependencies.sdl2]
-version = "0.29"
+version = "0.31"
 default-features = false
-features = ["ttf", "image"]
+features = ["ttf", "image", "unsafe_textures"]
 
 [profile.release]
 debug = true

--- a/examples/mario/Cargo.toml
+++ b/examples/mario/Cargo.toml
@@ -12,7 +12,7 @@ clippy = { version = "*", optional = true }
 path = "../../"
 
 [dependencies.sdl2]
-version = "0.31"
+version = "0.37"
 default-features = false
 features = ["ttf", "image", "unsafe_textures"]
 

--- a/examples/mario/src/actions.rs
+++ b/examples/mario/src/actions.rs
@@ -7,7 +7,8 @@ use mold2d::{
     ActorIndex, ActorManager, ActorPosition, ActorToken, CollisionSide, Context, MessageHandler,
     PositionChange, Viewport,
 };
-use sdl2::render::Renderer;
+use sdl2::render::Canvas;
+use sdl2::video::Window;
 
 /// Actions for an actor to process
 #[derive(Clone, Debug, PartialEq)]
@@ -62,16 +63,16 @@ pub fn actor_from_token(
     ActorToken(token): ActorToken,
     index: ActorIndex,
     position: ActorPosition,
-    renderer: &mut Renderer,
+    canvas: &mut Canvas<Window>,
 ) -> Box<Actor> {
     match token {
-        'P' => Box::new(Player::new(index, position, renderer, 30.)),
-        'C' => Box::new(Coin::new(index, position, renderer, 20.)),
-        'K' => Box::new(Koopa::new(index, position, renderer, 30.)),
-        'S' => Box::new(StartBlock::new(index, position, renderer, 1.)),
-        '=' => Box::new(GroundBlockTop::new(index, position, renderer, 1.)),
-        '-' => Box::new(GroundBlockMid::new(index, position, renderer, 1.)),
-        '_' => Box::new(StoneBlock::new(index, position, renderer, 1.)),
+        'P' => Box::new(Player::new(index, position, canvas, 30.)),
+        'C' => Box::new(Coin::new(index, position, canvas, 20.)),
+        'K' => Box::new(Koopa::new(index, position, canvas, 30.)),
+        'S' => Box::new(StartBlock::new(index, position, canvas, 1.)),
+        '=' => Box::new(GroundBlockTop::new(index, position, canvas, 1.)),
+        '-' => Box::new(GroundBlockMid::new(index, position, canvas, 1.)),
+        '_' => Box::new(StoneBlock::new(index, position, canvas, 1.)),
         _ => panic!("Actor not implemented for token!"),
     }
 }
@@ -89,7 +90,7 @@ pub fn handle_message(
     match *action {
         AddActor(token, pos) => {
             let next_index = actors.next_index();
-            let actor = actor_from_token(token, next_index.index(), pos, &mut context.renderer);
+            let actor = actor_from_token(token, next_index.index(), pos, &mut context.canvas);
             actors.add(next_index, actor);
         }
         RemoveActor(id) => actors.remove(id),

--- a/examples/mario/src/actors/coin.rs
+++ b/examples/mario/src/actors/coin.rs
@@ -20,7 +20,7 @@ impl Coin {
     pub fn new(
         index: ActorIndex,
         position: ActorPosition,
-        renderer: &mut Canvas<Window>,
+        canvas: &mut Canvas<Window>,
         fps: f64,
     ) -> Coin {
         let anim = Spritesheet::new(
@@ -30,7 +30,7 @@ impl Coin {
                 sprites_in_row: 8,
                 path: "./assets/coin.png",
             },
-            renderer,
+            canvas,
         );
 
         let anims = anim.range(0, 8);

--- a/examples/mario/src/actors/coin.rs
+++ b/examples/mario/src/actors/coin.rs
@@ -4,7 +4,8 @@ use mold2d::{
     Context, PositionChange, Renderable, SpriteRectangle, Spritesheet, SpritesheetConfig, Viewport,
 };
 use sdl2::rect::Rect;
-use sdl2::render::Renderer;
+use sdl2::render::Canvas;
+use sdl2::video::Window;
 use std::error::Error;
 
 const COIN_VALUE: i32 = 5;
@@ -19,7 +20,7 @@ impl Coin {
     pub fn new(
         index: ActorIndex,
         position: ActorPosition,
-        renderer: &mut Renderer,
+        renderer: &mut Canvas<Window>,
         fps: f64,
     ) -> Coin {
         let anim = Spritesheet::new(
@@ -92,7 +93,7 @@ impl Actor for Coin {
         let rect = Rect::new(rx, ry, self.rect.w, self.rect.h);
 
         // Render sprite animation
-        self.animation.render(&mut context.renderer, rect)
+        self.animation.render(&mut context.canvas, rect)
     }
 
     fn data(&mut self) -> ActorData {

--- a/examples/mario/src/actors/koopa.rs
+++ b/examples/mario/src/actors/koopa.rs
@@ -3,7 +3,7 @@ use mold2d::{
     Actor, ActorIndex, ActorPosition, Animations, BoundingBox, CollisionSide, Context, Direction,
     PositionChange, SpriteRectangle, Spritesheet, SpritesheetConfig, Vector2D, Viewport,
 };
-use sdl2::render::Renderer;
+use sdl2::{render::Canvas, video::Window};
 use std::error::Error;
 
 const KOOPA_X_MAXSPEED: f64 = 10.0;
@@ -42,7 +42,7 @@ impl Koopa {
     pub fn new(
         index: ActorIndex,
         position: ActorPosition,
-        renderer: &mut Renderer,
+        canvas: &mut Canvas<Window>,
         fps: f64,
     ) -> Koopa {
         use self::KoopaSize::*;
@@ -58,7 +58,7 @@ impl Koopa {
                 sprites_in_row: 4,
                 path: "./assets/koopa.png",
             },
-            renderer,
+            canvas,
         );
         let sanim = Spritesheet::new(
             SpritesheetConfig {
@@ -67,7 +67,7 @@ impl Koopa {
                 sprites_in_row: 4,
                 path: "./assets/shell.png",
             },
-            renderer,
+            canvas,
         );
 
         let bbox = BoundingBox::Rectangle(SpriteRectangle::new(
@@ -255,7 +255,7 @@ impl Actor for Koopa {
     ) -> Result<(), Box<dyn Error>> {
         let key = (self.curr_state, self.size, self.direction);
         self.anims
-            .render(&key, &self.rect, viewport, &mut context.renderer, false)
+            .render(&key, &self.rect, viewport, &mut context.canvas, false)
     }
 
     fn data(&mut self) -> ActorData {

--- a/examples/mario/src/actors/player.rs
+++ b/examples/mario/src/actors/player.rs
@@ -5,7 +5,8 @@ use mold2d::{
     Viewport,
 };
 use sdl2::pixels::Color;
-use sdl2::render::Renderer;
+use sdl2::render::Canvas;
+use sdl2::video::Window;
 use std::error::Error;
 
 const PLAYER_WIDTH: u32 = 30;
@@ -48,7 +49,7 @@ impl Player {
     pub fn new(
         index: ActorIndex,
         position: ActorPosition,
-        renderer: &mut Renderer,
+        canvas: &mut Canvas<Window>,
         fps: f64,
     ) -> Player {
         use self::PlayerSize::*;
@@ -64,7 +65,7 @@ impl Player {
                 sprites_in_row: 4,
                 path: "./assets/mario-big.png",
             },
-            renderer,
+            canvas,
         );
         let sanim = Spritesheet::new(
             SpritesheetConfig {
@@ -73,7 +74,7 @@ impl Player {
                 sprites_in_row: 4,
                 path: "./assets/mario-small.png",
             },
-            renderer,
+            canvas,
         );
 
         let bbox = BoundingBox::Rectangle(SpriteRectangle::new(
@@ -292,16 +293,16 @@ impl Actor for Player {
         if self.debug {
             let data = self.data();
             if let Some(ref mut segment) = self.prev_segment {
-                segment.render(Color::RGB(0, 0, 0), viewport, &mut context.renderer)?;
+                segment.render(Color::RGB(0, 0, 0), viewport, &mut context.canvas)?;
             }
             for side in data.rect.sides() {
-                side.render(Color::RGB(0, 255, 0), viewport, &mut context.renderer)?;
+                side.render(Color::RGB(0, 255, 0), viewport, &mut context.canvas)?;
             }
         }
 
         let key = (self.size, self.curr_state, self.direction);
         self.anims
-            .render(&key, &self.rect, viewport, &mut context.renderer, false)
+            .render(&key, &self.rect, viewport, &mut context.canvas, false)
     }
 
     fn data(&mut self) -> ActorData {

--- a/examples/mario/src/main.rs
+++ b/examples/mario/src/main.rs
@@ -3,8 +3,8 @@ pub mod actors;
 pub mod views;
 
 use crate::views::game_view::GameView;
-use mold2d::event_loop;
 use mold2d::Window;
+use mold2d::event_loop;
 
 fn main() {
     let window = Window {

--- a/examples/mario/src/views/background_view.rs
+++ b/examples/mario/src/views/background_view.rs
@@ -8,8 +8,8 @@ pub struct BackgroundView;
 impl View for BackgroundView {
     fn render(&mut self, context: &mut Context, _elapsed: f64) -> Result<(), Box<dyn Error>> {
         // TODO: Draw background (right now just draws red as background)
-        context.renderer.set_draw_color(Color::RGB(255, 0, 0));
-        context.renderer.clear();
+        context.canvas.set_draw_color(Color::RGB(255, 0, 0));
+        context.canvas.clear();
         Ok(())
     }
 

--- a/examples/mario/src/views/game_view.rs
+++ b/examples/mario/src/views/game_view.rs
@@ -1,5 +1,5 @@
-use crate::actions::{actor_from_token, handle_collision, handle_message, resolve_collision};
 use crate::actions::{Actor, ActorAction, ActorMessage, ActorType};
+use crate::actions::{actor_from_token, handle_collision, handle_message, resolve_collision};
 use crate::views::background_view::BackgroundView;
 use mold2d::font;
 use mold2d::level;
@@ -20,12 +20,8 @@ pub struct GameView {
 
 impl GameView {
     pub fn new(path: &str, context: &mut Context) -> GameView {
-        let level_result = level::load_level(
-            path,
-            actor_from_token,
-            &mut context.renderer,
-            &context.window,
-        );
+        let level_result =
+            level::load_level(path, actor_from_token, &mut context.canvas, &context.window);
         let (actors, viewport) = level_result.unwrap();
 
         if context.score.score("GAME_SCORE").is_none() {
@@ -46,8 +42,8 @@ impl View for GameView {
     #[inline]
     fn render(&mut self, context: &mut Context, elapsed: f64) -> Result<(), Box<dyn Error>> {
         // start off with a black screen
-        context.renderer.set_draw_color(Color::RGB(135, 206, 250));
-        context.renderer.clear();
+        context.canvas.set_draw_color(Color::RGB(135, 206, 250));
+        context.canvas.clear();
 
         // render contained actors
         for actor in self.actors.values_mut() {
@@ -64,7 +60,7 @@ impl View for GameView {
             if let Some(ref prev_score) = self.cached_score {
                 if *prev_score == score_text {
                     if let Some(ref font_sprite) = self.cached_font_sprite {
-                        font::render_text(&mut context.renderer, font_sprite, (100, 100))?;
+                        font::render_text(&mut context.canvas, font_sprite, (100, 100))?;
                     }
                     had_cached_score = true;
                 }
@@ -72,14 +68,14 @@ impl View for GameView {
 
             if !had_cached_score {
                 let font_sprite = font::text_sprite(
-                    &context.renderer,
+                    &context.canvas,
                     &score_text[..],
                     "assets/belligerent.ttf",
                     32,
                     Color::RGB(0, 255, 0),
                 )
                 .unwrap();
-                font::render_text(&mut context.renderer, &font_sprite, (100, 100))?;
+                font::render_text(&mut context.canvas, &font_sprite, (100, 100))?;
                 self.cached_score = Some(score_text);
                 self.cached_font_sprite = Some(font_sprite);
             }

--- a/src/actor_manager.rs
+++ b/src/actor_manager.rs
@@ -178,7 +178,8 @@ mod tests {
     use crate::vector::PositionChange;
     use crate::viewport::Viewport;
     use sdl2::rect::Rect;
-    use sdl2::render::Renderer;
+    use sdl2::render::Canvas;
+    use sdl2::video::Window;
     use std::error::Error;
 
     #[derive(Debug, Clone, PartialEq)]
@@ -227,7 +228,7 @@ mod tests {
         _token: ActorToken,
         index: ActorIndex,
         _position: ActorPosition,
-        _renderer: &mut Renderer,
+        _canvas: &mut Canvas<Window>,
     ) -> Box<dyn Actor<Type = (), Message = ()>> {
         Box::new(TestActor(index))
     }

--- a/src/block.rs
+++ b/src/block.rs
@@ -68,7 +68,7 @@ macro_rules! block {
             impl $name {
                 pub fn new(index: ::mold2d::ActorIndex,
                            position: ::mold2d::ActorPosition,
-                           renderer: &mut ::sdl2::render::Renderer,
+                           canvas: &mut ::sdl2::render::Canvas<::sdl2::video::Window>,
                            _fps: f64)
                            -> $name {
                     let anim_data = ::mold2d::SpritesheetConfig {
@@ -78,7 +78,7 @@ macro_rules! block {
                         path: $path,
                     };
 
-                    let anim = ::mold2d::Spritesheet::new(anim_data, renderer);
+                    let anim = ::mold2d::Spritesheet::new(anim_data, canvas);
                     let mut sprite_anims = anim.range($index, $index + 1);
                     let sprite = sprite_anims.pop().unwrap();
 
@@ -125,7 +125,7 @@ macro_rules! block {
                     let (rx, ry) = viewport.relative_point((self.rect.x, self.rect.y));
                     let rect = ::sdl2::rect::Rect::new(rx, ry, self.rect.w, self.rect.h);
 
-                    self.sprite.render(&mut context.renderer, rect)
+                    self.sprite.render(&mut context.canvas, rect)
                 }
 
                 fn data(&mut self) -> ::mold2d::ActorData<$actor_type> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,6 @@
 use crate::events::Events;
 use crate::score::Score;
-use sdl2::render::Renderer;
+use sdl2::render::Canvas;
 
 /// Represents a SDL window to render
 pub struct Window {
@@ -10,22 +10,22 @@ pub struct Window {
 }
 
 /// Contains the main context variables for the game
-/// like the renderer and the events triggered
-pub struct Context<'a> {
+/// like the canvas and the events triggered
+pub struct Context {
     pub events: Events,
-    pub renderer: Renderer<'a>,
+    pub canvas: Canvas<sdl2::video::Window>,
     pub window: Window,
     pub score: Score,
 }
 
-impl<'a> Context<'a> {
+impl Context {
     /// Creates a new context given the path for the keyboard configuration
-    /// and the sdl renderer
-    pub fn new(window: Window, events: Events, renderer: Renderer<'a>) -> Context<'a> {
+    /// and the sdl canvas
+    pub fn new(window: Window, events: Events, canvas: Canvas<sdl2::video::Window>) -> Context {
         Context {
             window,
             events,
-            renderer,
+            canvas,
             score: Score::new(),
         }
     }

--- a/src/event_loop/mod.rs
+++ b/src/event_loop/mod.rs
@@ -5,7 +5,7 @@ use super::{View, ViewAction};
 use crate::context::{Context, Window};
 use crate::events::Events;
 use sdl2;
-use sdl2::image::{INIT_JPG, INIT_PNG};
+use sdl2::image::InitFlag;
 use std::error::Error;
 
 /// Initializes SDL and creates the window and event loop
@@ -16,7 +16,7 @@ where
     let sdl_context = sdl2::init()?;
     let video = sdl_context.video()?;
     let mut timer = sdl_context.timer()?;
-    let _image_context = sdl2::image::init(INIT_PNG | INIT_JPG)?;
+    let _image_context = sdl2::image::init(InitFlag::PNG | InitFlag::JPG)?;
     let _ttf_context = sdl2::ttf::init()?;
 
     let mut frame_timer = FrameTimer::new(&mut timer, true);

--- a/src/event_loop/mod.rs
+++ b/src/event_loop/mod.rs
@@ -25,11 +25,11 @@ where
         .position_centered()
         .opengl()
         .build()?;
-    let sdl_renderer = sdl_window.renderer().accelerated().build()?;
+    let sdl_canvas = sdl_window.into_canvas().accelerated().build()?;
     let mut game_context = Context::new(
         window,
         Events::new(sdl_context.event_pump()?, ""),
-        sdl_renderer,
+        sdl_canvas,
     );
     let mut curr_view = init_view(&mut game_context);
 
@@ -50,7 +50,7 @@ where
         curr_view.render(&mut game_context, elapsed)?;
 
         // Render the scene
-        game_context.renderer.present();
+        game_context.canvas.present();
     }
 
     Ok(())

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -32,7 +32,7 @@ impl Events {
                     keycode: Some(keycode),
                     ..
                 } => {
-                    let action = match self.mappings.get_action(keycode as i32) {
+                    let action = match self.mappings.get_action(keycode.into_i32()) {
                         Some(action) => action,
                         None => return,
                     };
@@ -48,7 +48,7 @@ impl Events {
                     keycode: Some(keycode),
                     ..
                 } => {
-                    let action = match self.mappings.get_action(keycode as i32) {
+                    let action = match self.mappings.get_action(keycode.into_i32()) {
                         Some(action) => action.clone(),
                         None => return,
                     };

--- a/src/font.rs
+++ b/src/font.rs
@@ -2,25 +2,27 @@ use crate::cache;
 use crate::sprite::{Renderable, Sprite};
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
-use sdl2::render::Renderer;
+use sdl2::render::Canvas;
+use sdl2::video::Window;
 use std::error::Error;
 use std::path::Path;
 
 /// Returns a text sprite with the specified text, font, size, and color
 pub fn text_sprite(
-    renderer: &Renderer,
+    canvas: &Canvas<Window>,
     text: &str,
     font_path: &'static str,
     size: u16,
     color: Color,
 ) -> Result<Sprite, Box<dyn Error>> {
     let font_cache = cache::font_cache();
+    let creator = canvas.texture_creator();
 
     // if font is cached use the cached font
     if let Ok(ref cache) = font_cache.cache.lock() {
         if let Some(font) = cache.get(font_path) {
             let surface = font.render(text).blended(color)?;
-            let texture = renderer.create_texture_from_surface(&surface)?;
+            let texture = creator.create_texture_from_surface(&surface)?;
 
             return Ok(Sprite::new(texture));
         }
@@ -28,12 +30,11 @@ pub fn text_sprite(
 
     // otherwise load font from file path
     let font = cache::TTF_CONTEXT.load_font(Path::new(font_path), size)?;
-    let sprite;
 
     let surface = font.render(text).blended(color)?;
-    let texture = renderer.create_texture_from_surface(&surface)?;
+    let texture = creator.create_texture_from_surface(&surface)?;
 
-    sprite = Sprite::new(texture);
+    let sprite = Sprite::new(texture);
 
     // cache if successful
     let _ = font_cache
@@ -46,11 +47,11 @@ pub fn text_sprite(
 
 /// Renders a text sprite at the specified point
 pub fn render_text(
-    renderer: &mut Renderer,
+    canvas: &mut Canvas<Window>,
     sprite: &Sprite,
     point: (i32, i32),
 ) -> Result<(), Box<dyn Error>> {
     let (x, y) = point;
     let (w, h) = sprite.size();
-    sprite.render(renderer, Rect::new(x, y, w, h))
+    sprite.render(canvas, Rect::new(x, y, w, h))
 }

--- a/src/level.rs
+++ b/src/level.rs
@@ -2,7 +2,7 @@ use super::Actor;
 use crate::actor_manager::{ActorIndex, ActorManager, ActorPosition, ActorToken};
 use crate::context::Window;
 use crate::viewport::Viewport;
-use sdl2::render::Renderer;
+use sdl2::render::Canvas;
 use std::fs::File;
 use std::io;
 use std::io::{BufRead, BufReader};
@@ -13,12 +13,12 @@ pub const GRID_SIZE: i32 = 40;
 pub fn load_level<A, F>(
     path: &str,
     actor_for_token: F,
-    renderer: &mut Renderer,
+    canvas: &mut Canvas<sdl2::video::Window>,
     window: &Window,
 ) -> io::Result<(ActorManager<A>, Viewport)>
 where
     A: Actor + ?Sized,
-    F: Fn(ActorToken, ActorIndex, ActorPosition, &mut Renderer) -> Box<A>,
+    F: Fn(ActorToken, ActorIndex, ActorPosition, &mut Canvas<sdl2::video::Window>) -> Box<A>,
 {
     let mut center_point = (0, 0);
     let mut manager = ActorManager::new();
@@ -39,7 +39,7 @@ where
                         ActorToken(token),
                         next_index.index(),
                         ActorPosition(x, y),
-                        renderer,
+                        canvas,
                     );
                     manager.add(next_index, actor);
 

--- a/src/raycast.rs
+++ b/src/raycast.rs
@@ -3,7 +3,8 @@ use crate::vector::Vector2D;
 use crate::viewport::Viewport;
 use sdl2::pixels::Color;
 use sdl2::rect::{Point, Rect};
-use sdl2::render::Renderer;
+use sdl2::render::Canvas;
+use sdl2::video::Window;
 use std::error::Error;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -59,13 +60,13 @@ impl Segment {
         &self,
         color: Color,
         viewport: &mut Viewport,
-        renderer: &mut Renderer,
+        canvas: &mut Canvas<Window>,
     ) -> Result<(), Box<dyn Error>> {
         let (rx, ry) = viewport.relative_point((self.point.0 as i32, self.point.1 as i32));
         let p1 = Point::new(rx, ry);
         let p2 = Point::new(rx + (self.vector.x as i32), ry + (self.vector.y as i32));
-        renderer.set_draw_color(color);
-        renderer.draw_line(p1, p2).map_err(From::from)
+        canvas.set_draw_color(color);
+        canvas.draw_line(p1, p2).map_err(From::from)
     }
 }
 


### PR DESCRIPTION
Upgrades the rust-sdl2 package to 0.37 which is the latest version. Version 0.30 changes `Renderer` to `Canvas<Window>` and texture methods in `Renderer` are now in the canvas's texture creator. Textures also now have a lifetime which make it difficult to use the global texture cache. Because of that we enable the `unsafe_textures` feature to get rid of the lifetime on `Texture`.